### PR TITLE
Fix: Add config logging. Make variables local

### DIFF
--- a/lib/moesif_rack/app_config.rb
+++ b/lib/moesif_rack/app_config.rb
@@ -3,71 +3,71 @@ require 'json'
 require 'time'
 require 'zlib'
 require 'stringio'
+require_relative './helpers.rb'
 
 class AppConfig
 
-    def get_config(api_controller, debug)
+    def initialize debug
+        @debug = debug
+        @helpers = Helpers.new(debug)
+    end
+
+    def get_config(api_controller)
         # Get Application Config
         begin 
             config_api_response = api_controller.get_app_config()
+            @helpers.log_debug("new config downloaded")
+            @helpers.log_debug(config_api_response.to_s)
             return config_api_response
         rescue MoesifApi::APIException => e
             if e.response_code.between?(401, 403)
-                puts 'Unauthorized access getting application configuration. Please check your Appplication Id.'
+                @helpers.log_debug 'Unauthorized access getting application configuration. Please check your Appplication Id.'
             end
-            if debug
-                puts 'Error getting application configuration, with status code:'
-                puts e.response_code
-            end
+            @helpers.log_debug 'Error getting application configuration, with status code:'
+            @helpers.log_debug e.response_code
         rescue => e
-            if debug
-                puts e.to_s
-            end
+            @helpers.log_debug e.to_s
         end
         rescue
     end
 
-    def parse_configuration(config_api_response, debug)
+    def parse_configuration(config_api_response)
         # Parse configuration object and return Etag, sample rate and last updated time
         begin
             # Rails return gzipped compressed response body, so decompressing it and getting JSON response body
-            response_body = decompress_gzip_body(config_api_response, debug)
+            response_body = decompress_gzip_body(config_api_response)
+            @helpers.log_debug(response_body.to_s)
 
             # Check if response body is not nil
             if !response_body.nil? then 
                 # Return Etag, sample rate and last updated time
-                return config_api_response.headers[:x_moesif_config_etag], response_body.fetch("sample_rate", 100), Time.now.utc
+                return response_body, config_api_response.headers[:x_moesif_config_etag], Time.now.utc
             else
-                if debug
-                    puts 'Response body is nil, assuming default behavior'
-                end
+                @helpers.log_debug 'Response body is nil, assuming default behavior'
                 # Response body is nil, so assuming default behavior
                 return nil, 100, Time.now.utc
             end
         rescue => exception
-            if debug
-                puts 'Error while parsing the configuration object, assuming default behavior'
-                puts exception.to_s
-            end
+            @helpers.log_debug 'Error while parsing the configuration object, assuming default behavior'
+            @helpers.log_debug exception.to_s
             # Assuming default behavior
             return nil, 100, Time.now.utc
         end
     end
 
-    def get_sampling_percentage(config_api_response, user_id, company_id, debug)
+    def get_sampling_percentage(config_api_response, user_id, company_id)
         # Get sampling percentage
         begin
-            # Rails return gzipped compressed response body, so decompressing it and getting JSON response body
-            response_body = decompress_gzip_body(config_api_response, debug)
-
             # Check if response body is not nil
-            if !response_body.nil? then 
-                
+            if !config_api_response.nil? then 
+                @helpers.log_debug("Getting sample rate for user #{user_id} company #{company_id}")
+                @helpers.log_debug(config_api_response.to_s)
+
                 # Get user sample rate object
-                user_sample_rate = response_body.fetch('user_sample_rate', nil)
+                user_sample_rate = config_api_response.fetch('user_sample_rate', nil)
 
                 # Get company sample rate object
-                company_sample_rate = response_body.fetch('company_sample_rate', nil)
+                company_sample_rate = config_api_response.fetch('company_sample_rate', nil)
 
                 # Get sample rate for the user if exist
                 if !user_id.nil? && !user_sample_rate.nil? && user_sample_rate.key?(user_id)
@@ -80,22 +80,18 @@ class AppConfig
                 end
 
                 # Return sample rate
-                return response_body.fetch('sample_rate', 100)
+                return config_api_response.fetch('sample_rate', 100)
             else 
-                if debug
-                    puts 'Assuming default behavior as response body is nil - '
-                end
+                @helpers.log_debug 'Assuming default behavior as response body is nil - '
                 return 100
             end
         rescue => exception
-            if debug
-                puts 'Error while geting sampling percentage, assuming default behavior'
-            end
+            @helpers.log_debug 'Error while geting sampling percentage, assuming default behavior'
             return 100
         end
     end
 
-    def decompress_gzip_body(config_api_response, debug)
+    def decompress_gzip_body(config_api_response)
         # Decompress gzip response body
         begin
             # Check if the content-encoding header exist and is of type zip
@@ -110,16 +106,12 @@ class AppConfig
                 # Return the parsed body
                 return JSON.parse( uncompressed_string )
             else
-                if debug
-                    puts 'Content Encoding is of type other than gzip, returning nil'
-                end
+                @helpers.log_debug 'Content Encoding is of type other than gzip, returning nil'
                 return nil
             end
         rescue => exception
-            if debug
-                puts 'Error while decompressing the response body'
-                puts exception.to_s
-            end
+            @helpers.log_debug 'Error while decompressing the response body'
+            @helpers.log_debug exception.to_s
             return nil
         end
     end

--- a/lib/moesif_rack/helpers.rb
+++ b/lib/moesif_rack/helpers.rb
@@ -1,0 +1,14 @@
+require 'time'
+
+class Helpers
+
+    def initialize debug
+        @debug = debug
+    end
+
+    def log_debug(message)
+        if @debug
+            puts("#{Time.now.to_s} [Moesif Middleware] PID #{Process.pid} TID #{Thread.current.object_id} #{message}")
+        end
+    end
+end

--- a/moesif_rack.gemspec
+++ b/moesif_rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'moesif_rack'
-  s.version = '1.4.3'
+  s.version = '1.4.4'
   s.summary = 'moesif_rack'
   s.description = 'Rack/Rails middleware to log API calls to Moesif API analytics and monitoring'
   s.authors = ['Moesif, Inc', 'Xing Wang']


### PR DESCRIPTION
Variables like event sampling rate need to be local
Add more logging for config object
Don't keep decompressing config over and over.