### PR TITLE
Fix: Run new thread only if last worker run failed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    moesif_rack (1.4.8)
+    moesif_rack (1.4.9)
       moesif_api (~> 1.2, >= 1.2.12)
 
 GEM
@@ -48,6 +48,7 @@ GEM
 PLATFORMS
   java
   ruby
+  universal-java-1.8
 
 DEPENDENCIES
   moesif_api
@@ -56,4 +57,4 @@ DEPENDENCIES
   test-unit (~> 3.1, >= 3.1.5)
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/lib/moesif_rack/moesif_middleware.rb
+++ b/lib/moesif_rack/moesif_middleware.rb
@@ -296,7 +296,7 @@ module MoesifRack
             # Add Event to the queue
             @events_queue << event_model
             @helpers.log_debug("Event added to the queue ")
-            if Time.now.utc > (@last_config_download_time + 60)
+            if Time.now.utc > (@last_worker_run + 60)
               start_worker()
             end
 

--- a/moesif_rack.gemspec
+++ b/moesif_rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'moesif_rack'
-  s.version = '1.4.8'
+  s.version = '1.4.9'
   s.summary = 'moesif_rack'
   s.description = 'Rack/Rails middleware to log API calls to Moesif API analytics and monitoring'
   s.authors = ['Moesif, Inc', 'Xing Wang']


### PR DESCRIPTION
Fix: Run new thread only if last worker run failed
Bump version to 1.4.9