### PR TITLE
#185629329 : Update to faraday for client moesifapi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     moesif_rack (2.0.1)
       moesif_api (~> 2.0.1)
+      rack (~> 3.0.8, >= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -46,6 +47,7 @@ GEM
     netrc (0.11.0)
     power_assert (2.0.3)
     public_suffix (5.0.1)
+    rack (3.0.8)
     rake (13.0.6)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,26 @@
 PATH
   remote: .
   specs:
-    moesif_rack (1.5.1)
-      moesif_api (~> 1.2.17)
+    moesif_rack (2.0.1)
+      moesif_api (~> 2.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    connection_pool (2.4.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    faraday-net_http_persistent (2.1.0)
+      faraday (~> 2.5)
+      net-http-persistent (~> 4.0)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -20,13 +30,19 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
-    moesif_api (1.2.17)
+    moesif_api (2.0.1)
+      faraday (~> 2.7, >= 2.6)
+      faraday-net_http_persistent (~> 2.0, >= 2.0.1)
+      faraday-retry (~> 2.2.0, >= 2.0.0)
       json_mapper (~> 0.2, >= 0.2.1)
       moesif_unirest (~> 1.1.6)
+      net-http-persistent (~> 4.0, >= 4.0.1)
     moesif_unirest (1.1.6)
       addressable (~> 2.8, >= 2.8.0)
       json (~> 2.6, >= 2.6.1)
       rest-client (~> 2.1, >= 2.1.0)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     netrc (0.11.0)
     power_assert (2.0.3)
     public_suffix (5.0.1)
@@ -36,6 +52,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    ruby2_keywords (0.0.5)
     test-unit (3.6.1)
       power_assert
     unf (0.1.4)

--- a/lib/moesif_rack/app_config.rb
+++ b/lib/moesif_rack/app_config.rb
@@ -7,18 +7,37 @@ require_relative './moesif_helpers'
 require_relative './regex_config_helper'
 
 class AppConfig
+  attr_accessor :config, :recent_etag, :last_download_time
+
   def initialize(debug)
     @debug = debug
     @moesif_helpers = MoesifHelpers.new(debug)
     @regex_config_helper = RegexConfigHelper.new(debug)
   end
 
+  def should_reload(etag_from_create_event)
+    if @last_download_time.nil?
+      return true
+    elsif Time.now.utc > (@last_config_download_time + 300)
+      return true
+    elsif !etag_from_create_event.nil? && !@recent_etag.nil?
+      @moesif_helpers.log_debug('comparing if etag from event and recent etag match ' + etag_from_create_event + ' ' + @recent_etag)
+
+      return etag_from_create_event != @recent_etag
+    end
+    @moesif_helpers.log_debug('should skip reload config')
+    return false;
+  end
+
   def get_config(api_controller)
     # Get Application Config
+    @moesif_helpers.log_debug('try to loading etag')
     config_json, _context = api_controller.get_app_config
+    @config = config_json
+    @recent_etag = _context.response.headers[:x_moesif_config_etag]
+    @last_download_time = Time.now.utc
     @moesif_helpers.log_debug('new config downloaded')
-    @moesif_helpers.log_debug(config_api_response.to_s)
-    parse_configuration(config_json, _context)
+    @moesif_helpers.log_debug(config_json.to_s)
   rescue MoesifApi::APIException => e
     if e.response_code.between?(401, 403)
       @moesif_helpers.log_debug 'Unauthorized access getting application configuration. Please check your Appplication Id.'
@@ -29,34 +48,16 @@ class AppConfig
     @moesif_helpers.log_debug e.to_s
   end
 
-  def parse_configuration(config_json, _context)
-    # Parse configuration object and return Etag, sample rate and last updated time
-    # Rails return gzipped compressed response body, so decompressing it and getting JSON response body
-    # Check if response body is not nil
-    return config_json, _context.response.headers[:x_moesif_config_etag], Time.now.utc unless config_json.nil?
-
-    # Return Etag, sample rate and last updated time
-
-    @moesif_helpers.log_debug 'Response body is nil, assuming default behavior'
-    # Response body is nil, so assuming default behavior
-    [nil, nil, Time.now.utc]
-  rescue StandardError => e
-    @moesif_helpers.log_debug 'Error while parsing the configuration object, assuming default behavior'
-    @moesif_helpers.log_debug e.to_s
-    # Assuming default behavior
-    [nil, nil, Time.now.utc]
-  end
-
-  def get_sampling_percentage(event_model, config_api_response, user_id, company_id)
+  def get_sampling_percentage(event_model, user_id, company_id)
     # Get sampling percentage
-
-    # Check if response body is not nil
-    if !config_api_response.nil?
       @moesif_helpers.log_debug("Getting sample rate for user #{user_id} company #{company_id}")
-      @moesif_helpers.log_debug(config_api_response.to_s)
+      @moesif_helpers.log_debug(@config.to_s)
+
+      # if we do not have config for some reason we return 100
+      return 100 if @config.nil?
 
       # Get Regex Sampling rate
-      regex_config = config_api_response.fetch('regex_config', nil)
+      regex_config = @config.fetch('regex_config', nil)
 
       if !regex_config.nil? and !event_model.nil?
         config_mapping = @regex_config_helper.prepare_config_mapping(event_model)
@@ -66,10 +67,10 @@ class AppConfig
       end
 
       # Get user sample rate object
-      user_sample_rate = config_api_response.fetch('user_sample_rate', nil)
+      user_sample_rate = @config.fetch('user_sample_rate', nil)
 
       # Get company sample rate object
-      company_sample_rate = config_api_response.fetch('company_sample_rate', nil)
+      company_sample_rate = @config.fetch('company_sample_rate', nil)
 
       # Get sample rate for the user if exist
       if !user_id.nil? && !user_sample_rate.nil? && user_sample_rate.key?(user_id)
@@ -81,8 +82,8 @@ class AppConfig
         return company_sample_rate.fetch(company_id)
       end
 
-      # Return sample rate
-      config_api_response.fetch('sample_rate', 100)
+      # Return overall sample rate
+      @config.fetch('sample_rate', 100)
     else
       @moesif_helpers.log_debug 'Assuming default behavior as response body is nil - '
       100

--- a/lib/moesif_rack/app_config.rb
+++ b/lib/moesif_rack/app_config.rb
@@ -18,7 +18,7 @@ class AppConfig
   def should_reload(etag_from_create_event)
     if @last_download_time.nil?
       return true
-    elsif Time.now.utc > (@last_config_download_time + 300)
+    elsif Time.now.utc > (@last_download_time + 300)
       return true
     elsif !etag_from_create_event.nil? && !@recent_etag.nil?
       @moesif_helpers.log_debug('comparing if etag from event and recent etag match ' + etag_from_create_event + ' ' + @recent_etag)
@@ -49,12 +49,11 @@ class AppConfig
   end
 
   def get_sampling_percentage(event_model, user_id, company_id)
+    # if we do not have config for some reason we return 100
+    if !@config.nil?
     # Get sampling percentage
       @moesif_helpers.log_debug("Getting sample rate for user #{user_id} company #{company_id}")
       @moesif_helpers.log_debug(@config.to_s)
-
-      # if we do not have config for some reason we return 100
-      return 100 if @config.nil?
 
       # Get Regex Sampling rate
       regex_config = @config.fetch('regex_config', nil)

--- a/lib/moesif_rack/app_config.rb
+++ b/lib/moesif_rack/app_config.rb
@@ -15,10 +15,10 @@ class AppConfig
 
   def get_config(api_controller)
     # Get Application Config
-    config_api_response = api_controller.get_app_config
+    config_json, _context = api_controller.get_app_config
     @moesif_helpers.log_debug('new config downloaded')
     @moesif_helpers.log_debug(config_api_response.to_s)
-    config_api_response
+    parse_configuration(config_json, _context)
   rescue MoesifApi::APIException => e
     if e.response_code.between?(401, 403)
       @moesif_helpers.log_debug 'Unauthorized access getting application configuration. Please check your Appplication Id.'
@@ -29,15 +29,11 @@ class AppConfig
     @moesif_helpers.log_debug e.to_s
   end
 
-  def parse_configuration(config_api_response)
+  def parse_configuration(config_json, _context)
     # Parse configuration object and return Etag, sample rate and last updated time
-
     # Rails return gzipped compressed response body, so decompressing it and getting JSON response body
-    response_body = @moesif_helpers.decompress_gzip_body(config_api_response)
-    @moesif_helpers.log_debug(response_body.to_json)
-
     # Check if response body is not nil
-    return response_body, config_api_response.headers[:x_moesif_config_etag], Time.now.utc unless response_body.nil?
+    return config_json, _context.response.headers[:x_moesif_config_etag], Time.now.utc unless config_json.nil?
 
     # Return Etag, sample rate and last updated time
 

--- a/lib/moesif_rack/governance_rules.rb
+++ b/lib/moesif_rack/governance_rules.rb
@@ -109,10 +109,7 @@ class GovernanceRules
     # Get Application Config
     @last_fetch = Time.now.utc
     @moesif_helpers.log_debug('starting downlaoding rules')
-    rules_response = api_controller.get_rules
-    rules = @moesif_helpers.decompress_gzip_body(rules_response)
-    @moesif_helpers.log_debug('new rules downloaded')
-    @moesif_helpers.log_debug(rules.to_json)
+    rules, _context = api_controller.get_rules
 
     generate_rules_caching(rules)
   rescue MoesifApi::APIException => e

--- a/lib/moesif_rack/moesif_helpers.rb
+++ b/lib/moesif_rack/moesif_helpers.rb
@@ -12,30 +12,6 @@ class MoesifHelpers
     puts("#{Time.now} [Moesif Middleware] PID #{Process.pid} TID #{Thread.current.object_id} #{message}")
   end
 
-  def decompress_gzip_body(moesif_api_response)
-    # Decompress gzip response body
-
-    # Check if the content-encoding header exist and is of type zip
-    if moesif_api_response.headers.key?(:content_encoding) && moesif_api_response.headers[:content_encoding].eql?('gzip')
-
-      # Create a GZipReader object to read data
-      gzip_reader = Zlib::GzipReader.new(StringIO.new(moesif_api_response.raw_body.to_s))
-
-      # Read the body
-      uncompressed_string = gzip_reader.read
-
-      # Return the parsed body
-      JSON.parse(uncompressed_string)
-    else
-      @moesif_helpers.log_debug 'Content Encoding is of type other than gzip, returning nil'
-      nil
-    end
-  rescue StandardError => e
-    @moesif_helpers.log_debug 'Error while decompressing the response body'
-    @moesif_helpers.log_debug e.to_s
-    nil
-  end
-
   def format_replacement_body(replacement_body, original_body)
     # replacement_body is an hash or array json in this case.
     # but original body could be in chunks already. we want to follow suit.

--- a/moesif_capture_outgoing/httplog/http_log.rb
+++ b/moesif_capture_outgoing/httplog/http_log.rb
@@ -176,26 +176,9 @@ module MoesifCaptureOutgoing
               # we put in the queue and format abot it.
               unless @events_queue.nil?
                 @events_queue << event_model
+                puts('Outgoing Event successfully added to event queue') if @debug
                 return
               end
-
-              # event_api_response = @api_controller.create_event(event_model)
-              # event_response_config_etag = event_api_response[:x_moesif_config_etag]
-
-              # if !event_response_config_etag.nil? && !@config_etag.nil? && @config_etag != event_response_config_etag && Time.now.utc > @last_updated_time + 300
-              #   begin
-              #     new_config = @app_config.get_config(@api_controller)
-              #     unless new_config.nil?
-              #       @config, @config_etag, @last_config_download_time = @app_config.parse_configuration(new_config)
-              #     end
-              #   rescue StandardError => e
-              #     if @debug
-              #       puts 'Error while updating the application configuration'
-              #       puts e
-              #     end
-              #   end
-              # end
-              puts('Event successfully sent to Moesif') if @debug
             elsif @debug
               puts('Skipped outgoing Event due to sampling percentage: ' + @sampling_percentage.to_s + ' and random percentage: ' + @random_percentage.to_s)
             end

--- a/moesif_capture_outgoing/httplog/http_log.rb
+++ b/moesif_capture_outgoing/httplog/http_log.rb
@@ -175,7 +175,7 @@ module MoesifCaptureOutgoing
 
               # we put in the queue and format abot it.
               unless @events_queue.nil?
-                events_queue << event_model
+                @events_queue << event_model
                 return
               end
 

--- a/moesif_capture_outgoing/httplog/http_log.rb
+++ b/moesif_capture_outgoing/httplog/http_log.rb
@@ -28,19 +28,6 @@ module MoesifCaptureOutgoing
       @events_queue = events_queue
       @sampling_percentage = 100
       @last_updated_time = Time.now.utc
-
-      # most likeky won't need to reloaded again here.
-      # begin
-      #   new_config = @app_config.get_config(@api_controller)
-      #   unless new_config.nil?
-      #     @config, @config_etag, @last_config_download_time = @app_config.parse_configuration(new_config)
-      #   end
-      # rescue StandardError => e
-      #   if @debug
-      #     puts 'Error while parsing application configuration on initialization'
-      #     puts e
-      #   end
-      # end
     end
 
     def call(url, request, request_time, response, response_time)

--- a/moesif_rack.gemspec
+++ b/moesif_rack.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.add_development_dependency('test-unit', '~> 3.5', '>= 3.5.0')
   s.add_dependency('moesif_api', '~> 2.0.1')
+  s.add_dependency('rack', '~> 3.0.8', '>= 2.0.0')
   s.required_ruby_version = '>= 2.6'
   s.files = Dir['{bin,lib,moesif_capture_outgoing,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
@@ -21,5 +22,4 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/Moesif/moesif-rack",
     "wiki_uri"          => "https://github.com/Moesif/moesif-rack"
   }
-
 end

--- a/moesif_rack.gemspec
+++ b/moesif_rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'moesif_rack'
-  s.version = '1.5.1'
+  s.version = '2.0.1'
   s.summary = 'moesif_rack'
   s.description = 'Rack/Rails middleware to log API calls to Moesif API analytics and monitoring'
   s.authors = ['Moesif, Inc', 'Xing Wang']
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://moesif.com'
   s.license = 'Apache-2.0'
   s.add_development_dependency('test-unit', '~> 3.5', '>= 3.5.0')
-  s.add_dependency('moesif_api', '~> 1.2.17')
-  s.required_ruby_version = '>= 2.0'
+  s.add_dependency('moesif_api', '~> 2.0.1')
+  s.required_ruby_version = '>= 2.6'
   s.files = Dir['{bin,lib,moesif_capture_outgoing,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
   s.metadata = {

--- a/test/config_example.json
+++ b/test/config_example.json
@@ -1469,9 +1469,5 @@
     ]
   },
   "ip_addresses_blocked_by_name": {},
-  "regex_config": [],
-  "billing_config_jsons": {
-    "stripe": "{\"user_id_field\":\"id\",\"company_id_field\":\"metadata.uuid\"}",
-    "recurly": "{\"user_id_field\":\"account_code\",\"company_id_field\":\"uuid\"}"
-  }
+  "regex_config": []
 }

--- a/test/moesif_rack_test.rb
+++ b/test/moesif_rack_test.rb
@@ -72,9 +72,9 @@ class MoesifRackTest < Test::Unit::TestCase
     campaign_model = {"utm_source" => "Newsletter",
                       "utm_medium" => "Email"}
 
-    user_model = { "user_id" => "12345", 
+    user_model = { "user_id" => "12345",
                    "company_id" => "67890",
-                   "modified_time" => Time.now.utc.iso8601, 
+                   "modified_time" => Time.now.utc.iso8601,
                    "metadata" => metadata,
                    "campaign" => campaign_model}
 
@@ -91,14 +91,14 @@ class MoesifRackTest < Test::Unit::TestCase
 
     user_models = []
 
-    user_model_A = { "user_id" => "12345", 
+    user_model_A = { "user_id" => "12345",
                    "company_id" => "67890",
-                   "modified_time" => Time.now.utc.iso8601, 
+                   "modified_time" => Time.now.utc.iso8601,
                    "metadata" => metadata }
-    
+
     user_model_B = { "user_id" => "1234",
-                    "company_id" => "6789", 
-                    "modified_time" => Time.now.utc.iso8601, 
+                    "company_id" => "6789",
+                    "modified_time" => Time.now.utc.iso8601,
                     "metadata" => metadata }
 
     user_models << user_model_A << user_model_B
@@ -116,9 +116,10 @@ class MoesifRackTest < Test::Unit::TestCase
   def test_get_config
     @api_client = MoesifApi::MoesifAPIClient.new(@options['application_id'])
     @api_controller = @api_client.api
-    @config = @app_config.get_config(@api_controller)
-    @config_body, @config_etag, @last_updated_time = @app_config.parse_configuration(@config)
-    @sampling_percentage = @app_config.get_sampling_percentage(nil, @config_body, nil, nil)
+    @app_config.get_config(@api_controller)
+    @sampling_percentage = @app_config.get_sampling_percentage(nil, nil, nil)
+    assert_instance_of @app_config.config, Hash
+    print "app config from test " + @app_config.config.to_s
     assert_operator 100, :>=, @sampling_percentage
   end
 
@@ -132,8 +133,8 @@ class MoesifRackTest < Test::Unit::TestCase
     campaign_model = {"utm_source" => "Adwords",
                       "utm_medium" => "Twitter"}
 
-    company_model = { "company_id" => "12345", 
-                      "company_domain" => "acmeinc.com", 
+    company_model = { "company_id" => "12345",
+                      "company_domain" => "acmeinc.com",
                       "metadata" => metadata,
                       "campaign" => campaign_model }
 
@@ -151,11 +152,11 @@ class MoesifRackTest < Test::Unit::TestCase
     company_models = []
 
     company_model_A = { "company_id" => "12345",
-                        "company_domain" => "nowhere.com", 
+                        "company_domain" => "nowhere.com",
                    "metadata" => metadata }
-    
+
     company_model_B = { "company_id" => "1234",
-                        "company_domain" => "acmeinc.com", 
+                        "company_domain" => "acmeinc.com",
                     "metadata" => metadata }
 
     company_models << company_model_A << company_model_B

--- a/test/test_governance_rules.rb
+++ b/test/test_governance_rules.rb
@@ -1,6 +1,6 @@
 require 'moesif_api'
 require 'test/unit'
-require 'rack'
+
 require 'net/http'
 require_relative '../lib/moesif_rack/app_config'
 require_relative '../lib/moesif_rack'
@@ -61,10 +61,10 @@ class GovernanceRulesTest < Test::Unit::TestCase
     #for user id matched rules it depends on getting from config_rules_values
     #for that particular user id.
     # for this test case I will use this rule as fake input
-    #https://www.moesif.com/wrap/app/88:210-1051:5/governance-rule/64a5b8f9aca3042266d36ebc
+    #https://www.moesif.com/wrap/app/88:210-660:387/governance-rule/64a783a3e7d62b036d16006e
     config_user_rules_values = [
       {
-        "rules" => "64a5b8f9aca3042266d36ebc",
+        "rules" => "64a783a3e7d62b036d16006e",
         "values" => {
           "0" => "rome",
           "1" => "some value for 1",
@@ -105,9 +105,10 @@ class GovernanceRulesTest < Test::Unit::TestCase
     }
     user_id = 'vancouver1'
 
+    # https://www.moesif.com/wrap/app/88:210-660:387/governance-rule/64a783a43660b60f7c766a06
     config_user_rules_values = [
       {
-        "rules" => "64a5b8fa3660b60f7c7662fc",
+        "rules" => "64a783a43660b60f7c766a06",
         "values" => {
           "0" => "city",
           "1" => "some value for 1",

--- a/test/test_moesif_rack.rb
+++ b/test/test_moesif_rack.rb
@@ -4,8 +4,6 @@ require 'net/http'
 require_relative '../lib/moesif_rack/app_config.rb'
 require_relative '../lib/moesif_rack'
 
-print "hellow world"
-
 class MoesifRackTest < Test::Unit::TestCase
   def setup
     @app = ->(env) { [200, { "Content-Type" => "application/json" }, ["{ \"key\": \"value\"}"]]}
@@ -48,7 +46,6 @@ class MoesifRackTest < Test::Unit::TestCase
     }
   }
 
-    print "hellow world"
     @moesif_rack_app = MoesifRack::MoesifMiddleware.new(@app, @options)
     @app_config = AppConfig.new(true)
   end

--- a/test/test_moesif_rack.rb
+++ b/test/test_moesif_rack.rb
@@ -4,6 +4,8 @@ require 'net/http'
 require_relative '../lib/moesif_rack/app_config.rb'
 require_relative '../lib/moesif_rack'
 
+print "hellow world"
+
 class MoesifRackTest < Test::Unit::TestCase
   def setup
     @app = ->(env) { [200, { "Content-Type" => "application/json" }, ["{ \"key\": \"value\"}"]]}
@@ -45,6 +47,8 @@ class MoesifRackTest < Test::Unit::TestCase
       event_model
     }
   }
+
+    print "hellow world"
     @moesif_rack_app = MoesifRack::MoesifMiddleware.new(@app, @options)
     @app_config = AppConfig.new(true)
   end
@@ -118,7 +122,7 @@ class MoesifRackTest < Test::Unit::TestCase
     @api_controller = @api_client.api
     @app_config.get_config(@api_controller)
     @sampling_percentage = @app_config.get_sampling_percentage(nil, nil, nil)
-    assert_instance_of @app_config.config, Hash
+    assert_instance_of Hash, @app_config.config
     print "app config from test " + @app_config.config.to_s
     assert_operator 100, :>=, @sampling_percentage
   end


### PR DESCRIPTION
need more verifcaiton after moesifapi 2.0.1 is published. 

Major updates: 
1. No longer need to decompress gzip resposnes for app config or rules since it is parsed into "Hash" at the moesifapi level.
2. One shared instance of @app_config between normal middlware and capture outgoing. 
3. Move logic for determinie if should reload app config in AppConfig manager, and config itself into AppConfig manager. 
4. Captured outgoing events is also added to the event queue and batched together. 