### PR TITLE
#186918768 : support rest-client where it override standard stream object 

### DIFF
--- a/lib/moesif_rack/moesif_middleware.rb
+++ b/lib/moesif_rack/moesif_middleware.rb
@@ -18,7 +18,7 @@ module MoesifRack
       @app = app
       raise 'application_id required for Moesif Middleware' unless options['application_id']
 
-      @api_client = MoesifApi::MoesifAPIClient.new(options['application_id'], 'moesif-rack/2.2.2')
+      @api_client = MoesifApi::MoesifAPIClient.new(options['application_id'], 'moesif-rack/2.2.3')
       @api_controller = @api_client.api
 
       @api_version = options['api_version']

--- a/moesif_capture_outgoing/httplog/adapters/net_http.rb
+++ b/moesif_capture_outgoing/httplog/adapters/net_http.rb
@@ -19,7 +19,6 @@ module Net
         end
         result
       rescue StandardError => e
-        # do nothig for now
         return nil
       end
     end

--- a/moesif_capture_outgoing/httplog/adapters/net_http.rb
+++ b/moesif_capture_outgoing/httplog/adapters/net_http.rb
@@ -4,6 +4,26 @@ module Net
   class HTTP
     alias orig_request request unless method_defined?(:orig_request)
 
+    def extract_body_from_body_stream(body_stream)
+      begin
+        result = nil
+        if body_stream.respond_to?(:rewind) and body_stream.respond_to?(:read)
+          result = body_stream.read
+          body_stream.rewind
+        elsif body_stream.respond_to?(:to_s)
+          result = body_stream.to_s
+          if body_stream.respond_to?(:seek)
+             # if stream respond to seek let's reset seek to 0
+             body_stream.seek(0)
+          end
+        end
+        result
+      rescue StandardError => e
+        # do nothig for now
+        return nil
+      end
+    end
+
     def request(request, body = nil, &block)
       # Request Start Time
       request_time = Time.now.utc.iso8601(3)
@@ -11,8 +31,7 @@ module Net
       url = "https://#{@address}#{request.path}"
 
       if (not request.body_stream.nil?) && MoesifCaptureOutgoing.should_capture_body
-        req_body_from_stream = request.body_stream.read
-        request.body_stream.rewind
+        req_body_from_stream = extract_body_from_body_stream(request.body_stream)
       end
 
       # Response

--- a/moesif_capture_outgoing/httplog/http_log.rb
+++ b/moesif_capture_outgoing/httplog/http_log.rb
@@ -61,7 +61,15 @@ module MoesifCaptureOutgoing
         req_content_type = req_headers['content-type'].nil? ? req_headers['Content-Type'] : req_headers['content-type']
 
         # Request Body
-        req_body_string = request.body.nil? || request.body.empty? ? body_from_req_call : request.body
+        req_body_string = nil
+        if not (request.body.nil? || request.body.empty?)
+          req_body_string = request.body;
+        elsif not body_from_req_call.nil?
+          req_body_string = body_from_req_call
+        elsif req_body_from_stream.is_a? String
+          req_body_string = req_body_from_stream
+        end
+
         req_body_transfer_encoding = nil
         req_body = nil
 

--- a/moesif_rack.gemspec
+++ b/moesif_rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'moesif_rack'
-  s.version = '2.2.2'
+  s.version = '2.2.3'
   s.summary = 'moesif_rack'
   s.description = 'Rack/Rails middleware to log API calls to Moesif API analytics and monitoring'
   s.authors = ['Moesif, Inc', 'Xing Wang']


### PR DESCRIPTION

- rest-client hasn't been updated since August 2019. it doesn't look to be maintained anymore. 
- rest-client has this issue where it override the standard stream object with custom Payload object that does NOT implement standard "rewind" method. 

See issue here: https://github.com/rest-client/rest-client/issues/681

But this fix will work around that.
